### PR TITLE
Add Umami analytics script

### DIFF
--- a/themes/danntheme/layouts/partials/head.html
+++ b/themes/danntheme/layouts/partials/head.html
@@ -21,4 +21,5 @@
     {{ end }}
     <link rel="authorization_endpoint" href="https://indieauth.com/auth">
     <link rel="token_endpoint" href="https://tokens.indieauth.com/token">
+    <script defer src="https://analytics.dannb.org/script.js" data-website-id="94cc82e5-d526-4673-9d0f-cb8e0f165f99"></script>
 </head>


### PR DESCRIPTION
Adds Umami analytics script to the site head section to start collecting analytics data. The script is deferred to avoid blocking page rendering.