### PR TITLE
Add image modal functionality for blog posts

### DIFF
--- a/themes/danntheme/layouts/blog/single.html
+++ b/themes/danntheme/layouts/blog/single.html
@@ -5,7 +5,7 @@
     <h1 class="title">{{ .Title }}</h1>
         <p class="subtitle">By {{ .Site.Params.Author }}</p>
         <p class="date">Published or Updated on <time>{{ .PublishDate.Format "January 2, 2006" }}</time></p>
-    <div class="content">
+    <div class="content blog-post-content">
       {{ .Content }}
     </div>
   </article>

--- a/themes/danntheme/static/css/style.css
+++ b/themes/danntheme/static/css/style.css
@@ -292,3 +292,58 @@ pre {
 .button-link:hover {
   box-shadow: 6px 6px 0px #c00;
 }
+
+/* Image Modal Styles - Blog Posts Only */
+.blog-post-image-modal {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: fixed;
+  z-index: 9999;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0);
+  cursor: pointer;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.3s ease, visibility 0.3s ease, background-color 0.3s ease;
+}
+
+.blog-post-image-modal.active {
+  opacity: 1;
+  visibility: visible;
+  background-color: rgba(0, 0, 0, 0.6);
+}
+
+.blog-post-image-modal img {
+  max-width: 95%;
+  max-height: 95%;
+  object-fit: contain;
+  cursor: pointer;
+  margin: auto;
+  opacity: 0;
+  transform: scale(0.9);
+  transition: opacity 0.3s ease 0.1s, transform 0.3s ease 0.1s;
+}
+
+.blog-post-image-modal.active img {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.blog-post-image-modal img.png-image {
+  background-color: white;
+  padding: 20px;
+  border-radius: 4px;
+}
+
+.blog-post-content img {
+  cursor: pointer;
+  transition: opacity 0.2s ease;
+}
+
+.blog-post-content img:hover {
+  opacity: 0.9;
+}

--- a/themes/danntheme/static/js/script.js
+++ b/themes/danntheme/static/js/script.js
@@ -19,4 +19,84 @@ $(document).ready(function() {
             }
             return false;
         });
+
+        // Image modal functionality for blog posts only
+        const $blogContent = $('.blog-post-content');
+        if ($blogContent.length > 0) {
+            // Create modal element
+            const $modal = $('<div class="blog-post-image-modal"><img src="" alt=""></div>');
+            $('body').append($modal);
+
+            let scrollPosition = 0;
+
+            // Make images in blog posts clickable
+            $blogContent.find('img').each(function() {
+                const $img = $(this);
+                // Skip images that are already inside links
+                if ($img.closest('a').length === 0) {
+                    $img.css('cursor', 'pointer');
+                }
+            });
+
+            // Handle image click
+            $blogContent.on('click', 'img', function(e) {
+                const $img = $(this);
+                // Don't open modal if image is inside a link
+                if ($img.closest('a').length > 0) {
+                    return;
+                }
+
+                e.preventDefault();
+                e.stopPropagation();
+
+                // Store scroll position
+                scrollPosition = window.pageYOffset || document.documentElement.scrollTop;
+
+                // Set modal image source
+                const imgSrc = $img.attr('src') || $img.attr('data-src');
+                if (imgSrc) {
+                    const $modalImg = $modal.find('img');
+                    $modalImg.attr('src', imgSrc);
+                    $modalImg.attr('alt', $img.attr('alt') || '');
+                    
+                    // Check if image is PNG and add class for white background
+                    if (imgSrc.toLowerCase().endsWith('.png')) {
+                        $modalImg.addClass('png-image');
+                    } else {
+                        $modalImg.removeClass('png-image');
+                    }
+                    
+                    // Prevent body scroll
+                    $('body').css('overflow', 'hidden');
+                    // Trigger animation by adding active class
+                    setTimeout(function() {
+                        $modal.addClass('active');
+                    }, 10);
+                }
+            });
+
+            // Close modal on click anywhere (overlay or image)
+            $modal.on('click', function(e) {
+                closeModal();
+            });
+
+            // Close modal on escape key
+            $(document).on('keydown', function(e) {
+                if (e.key === 'Escape' && $modal.hasClass('active')) {
+                    closeModal();
+                }
+            });
+
+            function closeModal() {
+                $modal.removeClass('active');
+                // Remove PNG class when closing
+                $modal.find('img').removeClass('png-image');
+                // Wait for animation to complete before restoring scroll
+                setTimeout(function() {
+                    $('body').css('overflow', '');
+                    // Restore scroll position
+                    window.scrollTo(0, scrollPosition);
+                }, 300);
+            }
+        }
     });


### PR DESCRIPTION
This PR adds a premium image modal feature that allows users to click on images in blog posts to view them in an almost full-screen modal.

## Features
- Click any image in blog posts to open in modal (only applies to blog posts, not pages or home page)
- Smooth fade and scale animations when opening/closing
- Click anywhere (overlay or image) to close the modal
- Preserves scroll position when opening/closing
- PNG images with transparent backgrounds automatically get a white background in the modal
- Escape key support to close modal

## Technical Details
- Added `blog-post-content` class to blog post template for identification
- CSS transitions for smooth animations
- JavaScript handles image detection, modal creation, and event handling
- Respects existing links (images inside links won't trigger modal)