### PR TITLE
Fix RSS template for Hugo 0.158+ and bump Netlify to 0.161.1

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ publish = "public"
 command = "hugo --gc --minify"
 
 [context.production.environment]
-HUGO_VERSION = "0.69.2"
+HUGO_VERSION = "0.161.1"
 HUGO_ENV = "production"
 HUGO_ENABLEGITINFO = "true"
 
@@ -11,20 +11,20 @@ HUGO_ENABLEGITINFO = "true"
 command = "hugo --gc --minify --enableGitInfo"
 
 [context.split1.environment]
-HUGO_VERSION = "0.69.2"
+HUGO_VERSION = "0.161.1"
 HUGO_ENV = "production"
 
 [context.deploy-preview]
 command = "hugo --gc --minify --buildFuture -b $DEPLOY_PRIME_URL"
 
 [context.deploy-preview.environment]
-HUGO_VERSION = "0.69.2"
+HUGO_VERSION = "0.161.1"
 
 [context.branch-deploy]
 command = "hugo --gc --minify -b $DEPLOY_PRIME_URL"
 
 [context.branch-deploy.environment]
-HUGO_VERSION = "0.69.2"
+HUGO_VERSION = "0.161.1"
 
 [context.next.environment]
 HUGO_ENABLEGITINFO = "true"

--- a/themes/danntheme/layouts/_default/rss.xml
+++ b/themes/danntheme/layouts/_default/rss.xml
@@ -17,9 +17,9 @@
     <link>{{ .Permalink }}</link>
     <description>Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
     <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
-    <language>{{.}}</language>{{end}}{{ with .Site.Author.email }}
-    <managingEditor>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Author.email }}
-    <webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
+    <language>{{.}}</language>{{end}}{{ with .Site.Params.email }}
+    <managingEditor>{{.}}{{ with $.Site.Params.author }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Params.email }}
+    <webMaster>{{.}}{{ with $.Site.Params.author }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
     <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
     <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
     {{- with .OutputFormats.Get "RSS" -}}
@@ -30,7 +30,7 @@
       <title>{{ .Title }}</title>
       <link>{{ .Permalink }}</link>
       <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-      {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
+      {{ with .Site.Params.email }}<author>{{.}}{{ with $.Site.Params.author }} ({{.}}){{end}}</author>{{end}}
       <guid>{{ .Permalink }}</guid>
       <description>{{ .Content | html }}</description>
     </item>


### PR DESCRIPTION
## Summary
Resolves a local/production Hugo version drift that was crashing local builds.

- **RSS template fix:** `.Site.Author` was removed in Hugo v0.158, so the RSS template (`themes/danntheme/layouts/_default/rss.xml`) crashed the build on modern Hugo. Repointed the `managingEditor` / `webMaster` / `author` fields to `.Site.Params`. Since no email is configured, these fields render empty on both old and new Hugo — **output is byte-identical** to before.
- **Netlify Hugo bump:** `HUGO_VERSION` was pinned to `0.69.2` (2020) across all build contexts. Bumped to `0.161.1` to match the local toolchain.

## Why
Netlify was building on a 6-year-old Hugo, which is why production kept working while local builds (Hugo 0.161.1) failed. This aligns the two and prevents future drift.

## Verification
- Local `hugo server` (0.161.1) now builds clean and serves `200`.
- Generated `index.xml` renders identically — only `<language>` and `<copyright>` populate the channel; no author fields (none configured).

🤖 Generated with [Claude Code](https://claude.com/claude-code)