### PR TITLE
Keep home page lead paragraph beside floated profile image

### DIFF
--- a/themes/danntheme/static/css/style.css
+++ b/themes/danntheme/static/css/style.css
@@ -87,6 +87,11 @@ h3 {
 span.lead {
   font-size: 150%;
   margin: 1em 0;
+  /* Establish a block formatting context so the text forms a column beside
+     the floated profile image instead of wrapping underneath it. Without
+     this, the last line can spill below the image on some machines due to
+     font-rendering differences. */
+  display: flow-root;
 }
 div.boxed {
   display:  block;


### PR DESCRIPTION
## Problem

On the home page, the intro paragraph (`span.lead`) flows around the left-floated profile photo. Floated text fills the space to the right of the image and then continues **full-width below** it once it passes the image's bottom edge. Whether the last line (`big or scary.`) cleared the image or spilled underneath depended on the exact line count — which shifts by a pixel or two between machines due to font-rendering/metric differences. So it rendered correctly on most computers but dropped the last line below the photo on some.

## Fix

Give `span.lead` `display: flow-root`, which makes it establish a **block formatting context**. A BFC box is not allowed to overlap a float, so the whole paragraph now lays out as a rectangular column to the right of the photo and can never wrap beneath it — a deterministic layout rule rather than a font-metric race.

Notes:
- `flow-root` is supported in all current browsers; chosen over the older `overflow: hidden` BFC trick because it has no clipping side effects.
- Paragraphs after the lead are untouched and still wrap below the image as before.
- The mobile breakpoint (`max-width: 500px`) drops the float entirely, so this change is harmless there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)