### PR TITLE
Replace deprecated languageCode / .Site.LanguageCode (Hugo 0.158+)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
 baseURL = "https://dannb.org/"
-languageCode = "en-us"
+locale = "en-us"
 title = "Dann Berg: blog, newsletter, shop, and more"
 theme = "danntheme"
 rssLimit = 20

--- a/themes/danntheme/layouts/_default/baseof.html
+++ b/themes/danntheme/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.LanguageCode }}">
+<html lang="{{ .Site.Language.Locale }}">
     {{- partial "head.html" . -}}
     <body>
         {{- partial "header.html" . -}}

--- a/themes/danntheme/layouts/_default/rss.xml
+++ b/themes/danntheme/layouts/_default/rss.xml
@@ -16,7 +16,7 @@
     <title>{{ if eq  .Title  .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}</title>
     <link>{{ .Permalink }}</link>
     <description>Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
-    <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
+    <generator>Hugo -- gohugo.io</generator>{{ with .Site.Language.Locale }}
     <language>{{.}}</language>{{end}}{{ with .Site.Params.email }}
     <managingEditor>{{.}}{{ with $.Site.Params.author }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Params.email }}
     <webMaster>{{.}}{{ with $.Site.Params.author }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}


### PR DESCRIPTION
Resolves #54.

## Problem

Every Hugo build emitted two deprecation warnings:

```
WARN  deprecated: project config key languageCode was deprecated in Hugo v0.158.0 ... Use locale instead.
WARN  deprecated: .Site.LanguageCode was deprecated in Hugo v0.158.0 ... Use .Site.Language.Locale instead.
```

These are warnings today, but the APIs are slated for removal — a future Hugo upgrade could silently break the build.

## Changes

- **`config.toml`** — `languageCode = "en-us"` → `locale = "en-us"`
- **`baseof.html`** — `<html lang>` now uses `.Site.Language.Locale`
- **`rss.xml`** — `<language>` now uses `.Site.Language.Locale`

## Verification

Captured rendered output before the change, then confirmed it's unchanged after:

| Output | Before | After |
| --- | --- | --- |
| `<html lang>` | `en-us` | `en-us` |
| RSS `<language>` | `en-us` | `en-us` |

`hugo --gc --minify` now builds with **no** `deprecated` (or any other) warnings. No remaining `LanguageCode` references in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)