### PR TITLE
Add FinOps X 2026 talk recording link

### DIFF
--- a/content/blog/2026/ai-home-base.md
+++ b/content/blog/2026/ai-home-base.md
@@ -28,7 +28,7 @@ If you're interacting or doing tasks with AI today, there's a chance that you're
 
 I've coined the term **AI Home Base** for this setup. It's literally just a folder on your computer. But I'm going to share why this is so powerful and how you can set this up.
 
-I introduced the idea of an AI Home Base in my talk at the 2026 [FinOps X](https://x.finops.org) conference in San Diego. The session was recorded and will be published to YouTube — I'll update this post with a link once it's live. In the meantime, this article dives into the concept in full detail. I've also published a [companion GitHub repo](https://github.com/dannberg/finopsx-2026-ai-home-base) with some example folders, prompts, and skills. You're welcome to fork it as a starting point.
+I introduced the idea of an AI Home Base in my talk at the 2026 [FinOps X](https://x.finops.org) conference in San Diego. **[The recording is now live on YouTube](https://www.youtube.com/watch?v=t_rLbqeSCrU)** — watch it to see the concepts in action. This article dives into the concept in full detail. I've also published a [companion GitHub repo](https://github.com/dannberg/finopsx-2026-ai-home-base) with some example folders, prompts, and skills. You're welcome to fork it as a starting point.
 
 The AI Home Base is a simple concept, but oh-so-powerful.
 

--- a/content/start-here.md
+++ b/content/start-here.md
@@ -40,5 +40,6 @@ I've also published FinOps content sharing what I've learned. Here are my favori
 - [Creating a FinOps practice as the first practitioner](https://dannb.org/blog/2022/how-to-be-first-finops-practitioner/)
 - [Convincing Your Company Adopt Finops](https://dannb.org/blog/2023/convincing-your-company-adopt-finops/)
 - [Avoiding Lone FinOps Purgatory: When and how to grow your FinOps team](https://dannb.org/blog/2023/grow-your-finops-team/)
+- [Build Your AI Home Base: A Dead-Simple Setup for Knowledge Workers](https://dannb.org/blog/2026/ai-home-base/) (+ [companion repo](https://github.com/dannberg/finopsx-2026-ai-home-base) and [FinOps X 2026 talk recording](https://www.youtube.com/watch?v=t_rLbqeSCrU))
 
 I'm in the process of writing a book called _FinOps for Startups_ and I'm **[documenting the entire book research process](https://finopsforstartups.com)** in an effort to _Learn in Public_. You can **[subscribe](https://subscribe.finopsforstartups.com/)** to follow along.


### PR DESCRIPTION
The FinOps X 2026 talk recording is now live on YouTube. This PR updates two places:

**\`content/blog/2026/ai-home-base.md\`**
- Replaces the "session was recorded and will be published" placeholder with a live link to the YouTube recording.

**\`content/start-here.md\`**
- Adds the AI Home Base post to the FinOps section (it was missing), with inline links to the companion repo and talk recording.